### PR TITLE
Implement w3rc CLI to look up providers for a CID

### DIFF
--- a/cmd/w3rc/find.go
+++ b/cmd/w3rc/find.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ipfs-shipyard/w3rc/contentrouting"
+	"github.com/ipfs-shipyard/w3rc/contentrouting/delegated"
+	"github.com/ipfs/go-cid"
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/urfave/cli/v2"
+)
+
+var findCommand = &cli.Command{
+	Name:      "find",
+	Usage:     "Finds a list of providers for a given CID",
+	Action:    findAction,
+	Flags:     []cli.Flag{indexerFlag, timeoutFlag},
+	ArgsUsage: "<cid>",
+}
+
+func findAction(cctx *cli.Context) error {
+	if !cctx.Args().Present() {
+		return fmt.Errorf("a CID for which to find providers must be specified")
+	}
+
+	routing, err := delegated.NewDelegatedHTTP(indexer)
+	if err != nil {
+		return err
+	}
+
+	cidArg := cctx.Args().First()
+	target, err := cid.Decode(cidArg)
+	if err != nil {
+		return fmt.Errorf("failed to parse CID: %w", err)
+	}
+
+	ctxWithTimeout, cancel := context.WithTimeout(cctx.Context, timeout)
+	defer cancel()
+	providersChan := routing.FindProviders(ctxWithTimeout, target)
+	var providers []peer.AddrInfo
+	for rr := range providersChan {
+		if rErr, ok := rr.(*contentrouting.RoutingError); ok {
+			return rErr.Error
+		}
+
+		p, ok := rr.Provider().(peer.AddrInfo)
+		if !ok {
+			return fmt.Errorf("expected provider peer.AddrInfo in routing record but found: %v", rr.Provider())
+		}
+		providers = append(providers, p)
+	}
+	_, err = fmt.Fprintf(cctx.App.Writer, "Found %d provider(s) for CID %s\n", len(providers), cidArg)
+	if err != nil {
+		return err
+	}
+
+	for _, p := range providers {
+		_, err = fmt.Fprintf(cctx.App.Writer, "\t%v:\t%v\n", p.ID, p.Addrs)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/cmd/w3rc/flags.go
+++ b/cmd/w3rc/flags.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"time"
+
+	"github.com/urfave/cli/v2"
+)
+
+var (
+	indexer     string
+	indexerFlag = &cli.StringFlag{
+		Name:        "indexer",
+		Aliases:     []string{"i"},
+		Usage:       "The indexer HTTP endpoint URL.",
+		EnvVars:     []string{"W3RC_INDEXER"},
+		Required:    true,
+		Destination: &indexer,
+	}
+)
+
+var (
+	timeout     time.Duration
+	timeoutFlag = &cli.DurationFlag{
+		Name:        "timeout",
+		Aliases:     []string{"t"},
+		Usage:       "The maximum duration to wait for the command to complete.",
+		EnvVars:     []string{"W3RC_TIMEOUT"},
+		Required:    false,
+		Hidden:      false,
+		Value:       30 * time.Second,
+		Destination: &timeout,
+	}
+)

--- a/cmd/w3rc/script_test.go
+++ b/cmd/w3rc/script_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	mockdelegatedrouter "github.com/ipfs-shipyard/w3rc/contentrouting/delegated/mock"
+	"github.com/ipfs/go-cid"
+	"github.com/libp2p/go-libp2p-core/peer"
+	p2ptestutil "github.com/libp2p/go-libp2p-netutil"
+	"github.com/multiformats/go-multiaddr"
+	"github.com/multiformats/go-multicodec"
+	"github.com/multiformats/go-multihash"
+	"github.com/rogpeppe/go-internal/testscript"
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(testscript.RunMain(m, map[string]func() int{
+		"w3rc": run,
+	}))
+}
+
+func TestScript(t *testing.T) {
+
+	// Set up mock discoverable CID
+	p, err := p2ptestutil.RandTestBogusIdentity()
+	if err != nil {
+		t.Fatal(err)
+	}
+	mh, _ := multihash.Encode([]byte("fish"), multihash.IDENTITY)
+	foundCid := cid.NewCidV1(uint64(multicodec.DagPb), mh)
+	addr := peer.AddrInfo{
+		ID: p.ID(),
+		Addrs: []multiaddr.Multiaddr{
+			multiaddr.StringCast("/ip4/127.0.0.1/tcp/1234/tls"),
+		},
+	}
+
+	// Start mock indexer and make the mock CID discoverable
+	mockIndexer := mockdelegatedrouter.New()
+	listener, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+	go func() {
+		err := mockIndexer.Serve(listener)
+		if err != nil && err != http.ErrServerClosed {
+			t.Errorf("failed to start mock indexer server: %v", err)
+		}
+	}()
+	t.Cleanup(func() {
+		if err := mockIndexer.Close(); err != nil {
+			t.Fatalf("failed to close mock indexer: %v", err)
+		}
+	})
+	if err = mockIndexer.Add(foundCid, addr, 1, []byte("hello data")); err != nil {
+		t.Fatalf("failed to add mock discoverable CID: %v", err)
+	}
+
+	t.Parallel()
+	testscript.Run(t, testscript.Params{
+		Dir: filepath.Join("testdata", "script"),
+		Setup: func(env *testscript.Env) error {
+			mockIndexerAddr := fmt.Sprintf("http://%s", listener.Addr().String())
+			env.Setenv("MOCK_INDEXER", mockIndexerAddr)
+			env.Setenv("MOCK_DISCOVERABLE_CID", foundCid.String())
+			return nil
+		},
+	})
+}

--- a/cmd/w3rc/testdata/script/find.txt
+++ b/cmd/w3rc/testdata/script/find.txt
@@ -1,0 +1,24 @@
+# find without argumets is usage
+! w3rc find
+stderr 'Required flag "indexer" not set'
+stdout 'USAGE'
+
+# find without CID is error
+! w3rc find --indexer http://localhost:1234
+stderr 'a CID for which to find providers must be specified'
+! stdout .
+
+# find with invalid CID is error
+! w3rc find --indexer http://localhost:1234 fish
+stderr 'failed to parse CID: '
+! stdout .
+
+# find with vaild CID but offline indexer is error
+! w3rc find --indexer http://localhost:1234 ${MOCK_DISCOVERABLE_CID}
+stderr 'dial'
+! stdout .
+
+# find with disoverable CID and available indexer finds a provider
+w3rc find --indexer ${MOCK_INDEXER} ${MOCK_DISCOVERABLE_CID}
+stdout 'Found 1 provider.*'
+! stderr .

--- a/cmd/w3rc/testdata/script/w3rc.txt
+++ b/cmd/w3rc/testdata/script/w3rc.txt
@@ -1,0 +1,3 @@
+# USAGE is printed by default
+w3rc
+stdout 'USAGE'

--- a/cmd/w3rc/w3rc.go
+++ b/cmd/w3rc/w3rc.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/urfave/cli/v2"
+)
+
+func main() {
+	os.Exit(run())
+}
+
+func run() int {
+	app := &cli.App{
+		Name:  "w3rc",
+		Usage: "An experimental retrieval client for web3 content",
+		Commands: []*cli.Command{
+			findCommand,
+		},
+	}
+	if err := app.Run(os.Args); err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	return 0
+}

--- a/go.mod
+++ b/go.mod
@@ -18,4 +18,6 @@ require (
 	github.com/multiformats/go-multiaddr v0.4.0
 	github.com/multiformats/go-multicodec v0.3.0
 	github.com/multiformats/go-multihash v0.0.16
+	github.com/rogpeppe/go-internal v1.8.0
+	github.com/urfave/cli/v2 v2.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1061,6 +1061,8 @@ github.com/petar/GoLLRB v0.0.0-20210522233825-ae3b015fd3e9 h1:1/WtZae0yGtPq+TI6+
 github.com/petar/GoLLRB v0.0.0-20210522233825-ae3b015fd3e9/go.mod h1:x3N5drFsm2uilKKuuYo6LdyD8vZAW55sH/9w+pbo1sw=
 github.com/pierrec/lz4 v1.0.2-0.20190131084431-473cd7ce01a1/go.mod h1:3/3N9NVKO0jef7pBehbT1qWhCMrIgbYNnFAZCqQ5LRc=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
+github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e h1:aoZm08cpOy4WuID//EZDgcC4zIxODThtZNPirFr42+A=
+github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -1116,8 +1118,9 @@ github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qq
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
-github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
+github.com/rogpeppe/go-internal v1.8.0 h1:FCbCCtXNOY3UtUuHUYaghJg4y7Fd14rXifAYUAtL9R8=
+github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
 github.com/rs/zerolog v1.21.0/go.mod h1:ZPhntP/xmq1nnND05hhpAh2QMhSsA4UN3MGZ6O2J3hM=
 github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
@@ -1728,6 +1731,7 @@ gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/cheggaaa/pb.v1 v1.0.25/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
+gopkg.in/errgo.v2 v2.1.0 h1:0vLT13EuvQ0hNvakwLuFZ/jYrLp5F3kcWHXdRggjCE8=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/gcfg.v1 v1.2.3/go.mod h1:yesOnuUOFQAhST5vPY4nbZsb/huCgGGXlipJsBn0b3o=


### PR DESCRIPTION
Implement a CLI with `find` command that looks up the list of providers
for a given CID. The command takes

Add `testscript`s for the CLI that assert expected error messages in
negative cases, and a positive case via a mock indexer server.

Relates to:
 - https://github.com/ipfs-shipyard/w3rc/issues/6